### PR TITLE
july12: add `mailto:` to mail URI

### DIFF
--- a/july12/index.html
+++ b/july12/index.html
@@ -297,7 +297,7 @@
 
       <li>
         <h2>HELP US GET CREATIVE!</h2>
-        <p>We're just getting started with organizing this massive day of action, so sign up and we’ll get in touch soon with more information. If you have ideas or want to help, let us know. If you run a high-traffic website, startup, or small business, <a href="team@fightforthefuture.org">get in touch</a>. We need you!</p>
+        <p>We're just getting started with organizing this massive day of action, so sign up and we’ll get in touch soon with more information. If you have ideas or want to help, let us know. If you run a high-traffic website, startup, or small business, <a href="mailto:team@fightforthefuture.org">get in touch</a>. We need you!</p>
       </li>
       <li id="video">
         <h2>USE THIS VIDEO BUMPER</h2>


### PR DESCRIPTION
Currently, clicking on "get in touch" redirects you to https://www.battleforthenet.com/july12/team@fightforthefuture.org due to a missing `mailto:` in the anchor URI.