### PR TITLE
Fix ETHNews image asset source path and alt tag

### DIFF
--- a/july12/index.html
+++ b/july12/index.html
@@ -138,7 +138,7 @@
       <li><img src="/images/logos/eff-logo-plain-rgb.png" alt="EFF"></li>
       <li><img src="/images/logos/elastic.png" alt="Elastic.co"></li>
       <li><img src="/images/logos/engine.png" alt="Engine"></li>
-      <li><img src="/images/logos/ethnews.jpg" alt="Ethnews"></li>
+      <li><img src="/images/logos/ETHnews.png" alt="ETHNews"></li>
       <li><img src="/images/logos/expative.png" alt="Expative"></li>
       <li><img src="/images/logos/expertsexchange.png" alt="Experts Exchange"></li>
       <li><img src="/images/logos/fark.png" alt="Fark"></li>


### PR DESCRIPTION
GitHub pages is returning a 404 error for the ETHNews logo. This commit fixes #91.

The casing of the URL didn't match the actual filename in the `/logos` directory. I also switched from the _.jpg_ to the _.png_ file, already in the directory, because it was ½ the size and has a transparent background.

This commit corrects that, and it also updates the image alt attribute to reflect the same casing that ETHNews uses on their [About Us](https://www.ethnews.com/about-us) page.

##### Before

![screenshot-www battleforthenet com-2017-07-11-22-34-50](https://user-images.githubusercontent.com/1934719/28104041-f8ee6940-668d-11e7-9677-5c0f62856478.png)

##### After

![fixed](https://user-images.githubusercontent.com/1934719/28104082-22cb9aee-668e-11e7-8362-ba1e91753ebd.png)
