### PR TITLE
fix spacing in disclaimer

### DIFF
--- a/ts/disclaimer.tsx
+++ b/ts/disclaimer.tsx
@@ -25,7 +25,7 @@ export class Disclaimer extends React.Component<Props, State> {
         : <span className="note">
             {optIn
               ? <span>Allow {orgLink} to</span>
-              : <span>{orgLink} will</span>
+              : <span>{orgLink} will </span>
             }
             contact you about future campaigns. <a href="https://www.battleforthenet.com/privacy/" className="privacy-policy-link">Privacy Policy</a>
           </span>


### PR DESCRIPTION
Before this it was "willcontact" (see https://file.house/Ogmm.png),
Now it is proper ("will contact").