### PR TITLE
Horizontal overflow in mobile

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -33,6 +33,12 @@ a {
 
 img {
   border: none;
+  max-width: 100%;
+  height: auto;
+}
+
+iframe {
+  max-width: 100%;
 }
 
 body > main {

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
 				<li><img src="/images/logos/netflix.jpg" alt="Netflix"></li>
 				<li><img src="/images/logos/twitter.png" alt="Twitter"></li>
 				<li><img src="/images/logos/vimeo.png" alt="Vimeo"></li>
-        <li><img src="/images/logos/boingboing.png" alt="BoingBoing"></li>
+				<li><img src="/images/logos/boingboing.png" alt="BoingBoing"></li>
 				<li><img src="/images/logos/privateinternetaccess.png" alt="Private Internet Access"></li>
 				<li><img src="/images/logos/reddit.png" alt="Reddit"></li>
 				<li><img src="/images/logos/ycombinator.png" alt="Y Combinator"></li>

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
 				<li><img src="/images/logos/netflix.jpg" alt="Netflix"></li>
 				<li><img src="/images/logos/twitter.png" alt="Twitter"></li>
 				<li><img src="/images/logos/vimeo.png" alt="Vimeo"></li>
-                <li><img src="/images/logos/boingboing.png" alt="BoingBoing"></li>
+        <li><img src="/images/logos/boingboing.png" alt="BoingBoing"></li>
 				<li><img src="/images/logos/privateinternetaccess.png" alt="Private Internet Access"></li>
 				<li><img src="/images/logos/reddit.png" alt="Reddit"></li>
 				<li><img src="/images/logos/ycombinator.png" alt="Y Combinator"></li>

--- a/scss/index.scss
+++ b/scss/index.scss
@@ -93,9 +93,9 @@ $GRAY_LIGHT: #b1aedc;
       padding: 1rem;
       background-color: $WHITE;
       color: $BODY_BGCOLOR;
-			border-radius: 0.2rem;
-			overflow-x: scroll;
-			white-space: pre-wrap;
+      border-radius: 0.2rem;
+      overflow-x: scroll;
+      white-space: pre-wrap;
 
       & ::-moz-selection {
         background: $GRAY_LIGHT;

--- a/scss/index.scss
+++ b/scss/index.scss
@@ -68,6 +68,11 @@ $GRAY_LIGHT: #b1aedc;
 		margin-bottom:60px;
 	}
 
+	img {
+		max-width: 100%;
+		height: auto;
+	}
+
 
 	input {
 		font-family: "Montserrat", sans-serif;
@@ -88,7 +93,9 @@ $GRAY_LIGHT: #b1aedc;
       padding: 1rem;
       background-color: $WHITE;
       color: $BODY_BGCOLOR;
-      border-radius: 0.2rem;
+			border-radius: 0.2rem;
+			overflow-x: scroll;
+			white-space: pre-wrap;
 
       & ::-moz-selection {
         background: $GRAY_LIGHT;

--- a/scss/shareprogress-overrides.scss
+++ b/scss/shareprogress-overrides.scss
@@ -8,6 +8,7 @@
 			left: 0px;
 			width: 100%;
 			height: 100%;
+			padding: 0;
 		}
 	}
 }


### PR DESCRIPTION
Hey 👋

the current site has some overflow issues on smaller screens, causing an ugly scrollbar.
Example:

![image](https://user-images.githubusercontent.com/16670790/33147342-b48575c0-cfc7-11e7-866f-14128ccf85a4.png)

In particular, the `<pre>` element and `<img>`s without restrictions to the width were
the origin of this behavior. This PR should fix all of this.
  