### PR TITLE
Fix non-https youtube thumbnail source image on index.html to ensure secure browsing

### DIFF
--- a/index.html
+++ b/index.html
@@ -352,7 +352,7 @@
               {
                 heading: "Fight for the Future",
                 subHeading: "The Internet is under attack. This is the Battle for the Net.",
-                thumb: "http://img.youtube.com/vi/UsyzP5hejxI/maxresdefault.jpg",
+                thumb: "https://img.youtube.com/vi/UsyzP5hejxI/maxresdefault.jpg",
                 video: "https://www.youtube.com/embed/UsyzP5hejxI?rel=0&autoplay=1"
               },
               {


### PR DESCRIPTION
Summary:
------------
index.html is referencing a thumbnail resource from youtube at its `http` variant, instead of `https`, causing `battleforthenet.com` to load in mixed content mode rather than fully secure with SSL.

Changes proposed:
------------------
Replace the http protocol in `http://img.youtube.com/vi/UsyzP5hejxI/maxresdefault.jpg` with https

-----
Fixes #136