### PR TITLE
Use tel and email form types for nicer mobile experience

### DIFF
--- a/ts/templates.tsx
+++ b/ts/templates.tsx
@@ -22,14 +22,14 @@ export function PetitionFormTemplate(props:PetitionFormProps, state:PetitionForm
 						<input name="input_name" placeholder="Name" autoComplete="name" required value={state.input_name} onChange={ctx.handleInputChange} />
 					</div>
 					<div>
-						<input name="input_email" placeholder="E-mail" required value={state.input_email} onChange={ctx.handleInputChange} />
+						<input name="input_email" placeholder="E-mail" required value={state.input_email} onChange={ctx.handleInputChange} type="email" />
 					</div>
 					<div className="address-line">
 						<input name="input_address" className="address" placeholder="Address" required value={state.input_address} onChange={ctx.handleInputChange} />
 						{" "}
 						<input name="input_zip" className="zip" placeholder="Zip" required value={state.input_zip} onChange={ctx.handleInputChange} />
 					</div>
-					{props.swap ? "" : <div><input name="input_phone" className="phone" placeholder="Phone # (for text list)" value={state.input_phone} onChange={ctx.handleInputChange} /> </div> }
+					{props.swap ? "" : <div><input name="input_phone" className="phone" placeholder="Phone # (for text list)" value={state.input_phone} onChange={ctx.handleInputChange} type="tel" /> </div> }
 					<div className="letter">
 						<textarea ref={ctx.setTextarea} name="input_comment" required value={state.input_comment} onChange={ctx.handleInputChange} onFocus={ctx.onTextareaFocus} ></textarea>
 						<button onClick={ctx.onResetClick} className="reset">Clear and write your own</button>


### PR DESCRIPTION
These also fall back to input type=text style on older browsers
and desktop machines. But on phones, they trigger the nicer
keyboards that make it easier to type email addresses and phone
numbers.