### PR TITLE
BTI: participants CSS fix

### DIFF
--- a/breaktheinternet/css/style.css
+++ b/breaktheinternet/css/style.css
@@ -229,6 +229,11 @@ form input:nth-child(even) {
   align-items: center;
   justify-content: center;
   height: 70px;
+  overflow: hidden;
+}
+
+.participants img {
+  max-height: 60px;
 }
 
 .action-comment input[type=text] {
@@ -463,5 +468,14 @@ body.dp .hidden-dp {
     width: 100%;
     margin-right: 0;
     margin-bottom: 10px;
+  }
+  #participants li {
+    width: 48%;
+    margin-right: 2%;
+    margin-left: 0;
+  }
+
+  #participants li:nth-child(even) {
+    margin-right: 0;
   }
 }


### PR DESCRIPTION
* Prevent images from jumping out of box
* Make images 50% width on small screens