### PR TITLE
Make logos more balanced in total size

### DIFF
--- a/pages/augustrecess.vue
+++ b/pages/augustrecess.vue
@@ -350,8 +350,13 @@ form .disclaimer small {
     background: $body-bg-color-alt-1;
 
     img {
-      height: 3rem;
+      height: 3.5rem;
       margin: 1rem 3rem;
+    }
+
+    img.fftf {
+      height: 2.5rem;
+      margin: 1.5rem 3rem;
     }
 
     &:after {
@@ -560,7 +565,7 @@ form .disclaimer small {
       <div class="logos">
         <a href="https://www.fightforthefuture.org">
           <img src="~/assets/images/fftf-white-logo.png"
-               alt="Fight for the Future">
+               alt="Fight for the Future" class="fftf">
         </a>
         <a href="https://www.demandprogress.org">
           <img src="~/assets/images/demand-progress-white-logo.png"


### PR DESCRIPTION
FFTF's logo is wider than the others, so by making it shorter we give everybody more equal weight.
<img width="1172" alt="screen shot 2018-08-03 at 3 28 26 pm" src="https://user-images.githubusercontent.com/171493/43662048-844186fa-9732-11e8-8757-f0e2b225328e.png">
