### PR TITLE
Handle no-photo a little more gracefully

### DIFF
--- a/components/ScoreboardPhoto.vue
+++ b/components/ScoreboardPhoto.vue
@@ -2,9 +2,10 @@
 .scoreboard-photo {
   position: relative;
   border-radius: $border-radius;
-  display: inline-block;
+  display: block;
   width: 10rem;
   height: 12.2rem;
+  margin-bottom: 1rem;
 
   img, .cover, .yes-bg {
     width: 100%;

--- a/pages/scoreboard/_id.vue
+++ b/pages/scoreboard/_id.vue
@@ -130,6 +130,7 @@
   .scoreboard-photo {
     width: 17rem;
     height: auto;
+    margin-bottom: 0;
 
     @include mobile {
       width: 15rem;
@@ -152,6 +153,7 @@
 
     button, .btn {
       flex: 1;
+      min-height: 6.158rem;
       border-radius: $border-radius;
       font-size: 2.2rem;
       font-weight: 700;
@@ -166,6 +168,10 @@
       align-items: center;
       justify-content: center;
       position: relative;
+
+      @include mobile {
+        min-height: 3.459rem;
+      }
 
       &:last-child {
         margin-bottom: 0;


### PR DESCRIPTION
This is in lieu of putting a variable that indicates no photo is present in the main data feed. Some of the box-model changes are helpful regardless.

<img width="892" alt="screen shot 2019-01-02 at 1 59 34 pm" src="https://user-images.githubusercontent.com/171493/50608640-3a290f80-0e9b-11e9-9757-131c970830f2.png">

<img width="889" alt="screen shot 2019-01-02 at 2 24 19 pm" src="https://user-images.githubusercontent.com/171493/50608649-3f865a00-0e9b-11e9-9db9-b99e6e87c3d1.png">

<img width="810" alt="screen shot 2019-01-02 at 2 22 30 pm" src="https://user-images.githubusercontent.com/171493/50608653-41e8b400-0e9b-11e9-993c-309c8c903990.png">
